### PR TITLE
use of upload-on-branch variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,14 +9,14 @@ source:
     git_rev: v{{ version }}
 
 build:
-    number: 4 
-    script: python setup.py install --single-version-externally-managed --record=record.txt
+    number: 6 
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     skip: True  # [py2k] 
 
 requirements:
     build:
         - python
-        - setuptools
+        - pip
     run:
         - cycler
         - databroker


### PR DESCRIPTION
- Showing how commits from branches other than master from same repo won't
trigger uploads
- Example for PR