### PR TITLE
use of upload_on_branch field

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,10 +13,12 @@ jobs:
       linux_python3.6:
         CONFIG: linux_python3.6
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_python3.7:
         CONFIG: linux_python3.7
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
@@ -29,6 +31,11 @@ jobs:
 
   - script: |
         export CI=azure
+        if [ "$(Build.SourceBranch)" == "refs/heads/$UPLOAD_ON_BRANCH" -a $UPLOAD_PACKAGES == "True" ]; then
+            export UPLOAD_PACKAGES=True
+        else
+            export UPLOAD_PACKAGES=False
+        fi
         .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,9 +13,11 @@ jobs:
       osx_python3.6:
         CONFIG: osx_python3.6
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
       osx_python3.7:
         CONFIG: osx_python3.7
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
 
   steps:
   # TODO: Fast finish on azure pipelines?
@@ -75,3 +77,4 @@ jobs:
     displayName: Upload recipe
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+    condition: and(eq(variables['UPLOAD_PACKAGES'], 'True'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['UPLOAD_ON_BRANCH'])))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,10 +14,12 @@ jobs:
         CONFIG: win_python3.6
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
       win_python3.7:
         CONFIG: win_python3.7
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
+        UPLOAD_ON_BRANCH: master
   steps:
     # TODO: Fast finish on azure pipelines?
     - script: |
@@ -102,3 +104,4 @@ jobs:
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      condition: and(eq(variables['UPLOAD_PACKAGES'], 'True'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['UPLOAD_ON_BRANCH'])))

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -20,3 +20,4 @@ provider:
   linux: azure
   osx: azure
   win: azure
+upload_on_branch: master

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     git_rev: v{{ version }}
 
 build:
-    number: 5 
+    number: 6 
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     skip: True  # [py2k] 
 


### PR DESCRIPTION
- Build No. 6
- Showing how changes commited on branches other than that specified by 'upload_on_branch' from the same repo won't trigger uploads to anaconda.org
- Example for PR